### PR TITLE
Add finite value checks to LatentNeuroVec

### DIFF
--- a/R/latent_vec.R
+++ b/R/latent_vec.R
@@ -158,6 +158,17 @@ LatentNeuroVec <- function(basis, loadings, space, mask, offset = NULL, label = 
     stop(paste0("'loadings' must have ", cardinality, " rows (i.e. #non-zero in mask)"))
   }
 
+  # Ensure all numeric inputs are finite
+  if (!all(is.finite(basis))) {
+    stop("'basis' must contain only finite values")
+  }
+  if (!all(is.finite(loadings))) {
+    stop("'loadings' must contain only finite values")
+  }
+  if (length(offset) > 0 && !all(is.finite(offset))) {
+    stop("'offset' must contain only finite values")
+  }
+
   # Convert basis/loadings to Matrix objects, choosing dense/sparse based on density
   if (is.matrix(basis) && !is(basis, "Matrix")) {
       density_basis <- sum(basis != 0) / length(basis)

--- a/tests/testthat/test_latent_vec.R
+++ b/tests/testthat/test_latent_vec.R
@@ -251,9 +251,28 @@ test_that("LatentNeuroVec constructor validates dimensions correctly", {
                
   # Invalid: Offset length mismatch
   offset_bad_len <- rnorm(comps$nVox + 1)
-  expect_error(LatentNeuroVec(basis=comps$basis, loadings=comps$loadings, 
-                              space=comps$space, mask=comps$mask, offset=offset_bad_len), 
+  expect_error(LatentNeuroVec(basis=comps$basis, loadings=comps$loadings,
+                              space=comps$space, mask=comps$mask, offset=offset_bad_len),
                regexp="'offset' length must match number of rows in 'loadings'")
+
+  # Invalid: Non-finite values
+  basis_bad_na <- comps$basis
+  basis_bad_na[1,1] <- NA_real_
+  expect_error(LatentNeuroVec(basis=basis_bad_na, loadings=comps$loadings,
+                              space=comps$space, mask=comps$mask, offset=comps$offset),
+               regexp="basis.*finite")
+
+  loadings_bad_inf <- comps$loadings
+  loadings_bad_inf[1,1] <- Inf
+  expect_error(LatentNeuroVec(basis=comps$basis, loadings=loadings_bad_inf,
+                              space=comps$space, mask=comps$mask, offset=comps$offset),
+               regexp="loadings.*finite")
+
+  offset_bad_na2 <- comps$offset
+  offset_bad_na2[1] <- NA_real_
+  expect_error(LatentNeuroVec(basis=comps$basis, loadings=comps$loadings,
+                              space=comps$space, mask=comps$mask, offset=offset_bad_na2),
+               regexp="offset.*finite")
                
   # Invalid: Mask space mismatch
   # TODO LogicalNeuroVol constructor is not working as expected


### PR DESCRIPTION
## Summary
- ensure LatentNeuroVec only accepts finite numeric values
- test constructor handling of NA/Inf values

## Testing
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*