### PR TITLE
Ensure write_labeled_vec leaves HDF5 handle open

### DIFF
--- a/R/labeled_vec.R
+++ b/R/labeled_vec.R
@@ -29,6 +29,12 @@
 #' augment *some* additional fields (e.g., \code{qform_code=1L}). See implementation
 #' notes for which fields are protected.
 #'
+#' @section Lifecycle Management:
+#' The HDF5 file is opened in write mode and the resulting handle is returned
+#' without being automatically closed. **It is the caller's responsibility to
+#' close this handle** (via \code{h5file$close_all()} or \code{close()}) when
+#' finished working with the file.
+#'
 #' @param vec A 4D \code{\link[neuroim2]{NeuroVec}} with dimension \code{[X,Y,Z,nVols]}.
 #' @param mask A \code{\link[neuroim2]{LogicalNeuroVol}} of shape \code{[X,Y,Z]}
 #'   (the same 3D shape as \code{vec}).
@@ -44,8 +50,9 @@
 #'   `vec` or `mask` (like `dim`, `pixdim`, quaternion fields) cannot be overridden here.
 #' @param verbose Logical, whether to print verbose messages during processing.
 #'
-#' @return Invisibly returns the \code{\link[hdf5r]{H5File}} object, which now
-#'   has all the data and header info stored in it.
+#' @return Invisibly returns the open \code{\link[hdf5r]{H5File}} handle
+#'   containing the written data. The caller should close this handle when
+#'   finished.
 #'
 #' @seealso
 #' \code{\link[neuroim2]{matrixToQuatern}} for how the quaternion is derived,
@@ -111,8 +118,6 @@ write_labeled_vec <- function(vec,
   # === Open file using helper ===
   fh <- open_h5(file, mode = "w") # Use write mode
   h5obj <- fh$h5
-  # Use on.exit within the function frame, using safe helper
-  if (fh$owns) on.exit(safe_h5_close(h5obj), add = TRUE)
   
   # Get dimensions (already validated above)
   X <- nd[1]; Y <- nd[2]; Z <- nd[3]

--- a/man/write_labeled_vec.Rd
+++ b/man/write_labeled_vec.Rd
@@ -41,8 +41,9 @@ Default is \code{hdf5r::h5types$H5T_NATIVE_DOUBLE}.}
 \item{verbose}{Logical, whether to print verbose messages during processing.}
 }
 \value{
-Invisibly returns the \code{\link[hdf5r]{H5File}} object, which now
-  has all the data and header info stored in it.
+Invisibly returns the open \code{\link[hdf5r]{H5File}} handle containing
+  the written data. Close this handle with \code{close()} or
+  \code{h5file\$close_all()} when finished.
 }
 \description{
 Creates an HDF5 file following a NIfTI-like header layout, storing:
@@ -72,6 +73,11 @@ We store a subset of NIfTI-like header fields in the \code{/header} group.
 The user can supply \code{header_values} (a named list) to override or
 augment *some* additional fields (e.g., \code{qform_code=1L}). See implementation
 notes for which fields are protected.
+}
+\section{Lifecycle Management}{
+The file is opened in write mode and the resulting HDF5 handle is returned
+without being automatically closed. It is the user's responsibility to close
+this handle once writing is complete.
 }
 \seealso{
 \code{\link[neuroim2]{matrixToQuatern}} for how the quaternion is derived,


### PR DESCRIPTION
## Summary
- describe lifecycle management for `write_labeled_vec`
- keep the handle open by removing the on.exit close
- document the returned handle in the Rd file

## Testing
- `R` not installed, so tests could not be run