### PR TITLE
Remove /original_labels dependency

### DIFF
--- a/R/labeled_vec.R
+++ b/R/labeled_vec.R
@@ -346,18 +346,6 @@ read_labeled_vec <- function(file_path) {
 
   # Read labels from root level
   labels_arr <- .rd_root("labels")
-  
-  # Check if we have sanitized labels (original_labels dataset exists)
-  original_labels <- .rd_root("original_labels")
-  has_sanitized_labels <- !is.null(original_labels)
-  
-  # Use the original labels if available, otherwise use the standard labels
-  if (has_sanitized_labels) {
-    # Keep track of the sanitized->original mapping
-    safe_labels <- labels_arr
-    labels_arr <- original_labels
-  }
-
   if (is.null(labels_arr)) {
       stop("Mandatory '/labels' dataset not found at file root.")
   }
@@ -434,8 +422,6 @@ read_labeled_vec <- function(file_path) {
   load_env$mask_idx <- which(as.logical(mask_arr)==TRUE) # Ensure logical mask used
   load_env$dims     <- c(X,Y,Z)
   load_env$space    <- spc
-  # Store original labels 
-  load_env$original_labels <- labels_arr
   # Remove sanitize function from environment
   # load_env$sanitize_label <- function(lbl) { gsub("[^A-Za-z0-9_.-]", "_", lbl) }
 
@@ -541,7 +527,6 @@ setMethod(
     # 1) Figure out any missing dims => use full range
     dims_3d <- dim(space(x@mask))
     nVols   <- length(x@labels)
-
     # Handle missing i/j/k/l by using full ranges
     if (missing(i)) i <- seq_len(dims_3d[1])
     if (missing(j)) j <- seq_len(dims_3d[2])

--- a/tests/testthat/test_labeled_vec.R
+++ b/tests/testthat/test_labeled_vec.R
@@ -419,3 +419,26 @@ test_that("local_tempfile path is respected", {
   expect_false(file.exists(tmp))
 })
 
+
+
+# Regression: label round-trip without /original_labels dataset
+
+test_that("labels persist without /original_labels", {
+  skip_if_not_installed("hdf5r")
+
+  toy <- make_toy_vec(nx = 2, ny = 2, nz = 1, nvol = 2)
+  vec  <- toy$vec
+  mask <- toy$mask
+  lbls <- c("cond/A", "cond B")
+
+  tmp <- withr::local_tempfile(fileext = ".h5")
+  write_labeled_vec(vec, mask, lbls, tmp)
+
+  h5 <- hdf5r::H5File$new(tmp, "r")
+  expect_false(h5$exists("/original_labels"))
+  h5$close_all()
+
+  lvs <- read_labeled_vec(tmp)
+  expect_identical(lvs@labels, lbls)
+  close(lvs)
+})


### PR DESCRIPTION
## Summary
- drop `/original_labels` fallback in `read_labeled_vec`
- adjust environment setup accordingly
- add regression test for labels round‐trip without `/original_labels`

## Testing
- ❌ `R` command not found; unable to run R `testthat` suite