### PR TITLE
Replace try close patterns with helper

### DIFF
--- a/R/cluster_array.R
+++ b/R/cluster_array.R
@@ -119,7 +119,7 @@ setMethod("h5file", "H5ClusteredArray", function(x) x@obj)
 
             # Close dataset handle immediately after reading
             if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) {
-                 try(ds$close(), silent = TRUE)
+                 close_h5_safely(ds)
             }
 
             expected_rows <- length(row_indices_in_result)
@@ -134,7 +134,7 @@ setMethod("h5file", "H5ClusteredArray", function(x) x@obj)
 
         }, error = function(e) {
             if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) {
-                try(ds$close(), silent = TRUE)
+                close_h5_safely(ds)
             }
             stop(sprintf("[.get_cluster_timeseries] Failed processing cluster %d at path '%s'. Original error: %s", cid, dset_path, e$message))
         })
@@ -713,7 +713,7 @@ make_run_full <- function(file_source, scan_name,
                         }, error = function(e) {
                             warning(sprintf("[make_run_full] Error reading dimensions from '%s': %s", dset_path_cid1, e$message))
                         }, finally = {
-                             if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) try(ds$close(), silent = TRUE) # Close dataset handle
+                             if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) close_h5_safely(ds) # Close dataset handle
                         })
                     } else {
                        warning(sprintf("[make_run_full] Could not find or access dataset for first cluster (%d) at path '%s' to infer n_time.", first_cid, dset_path_cid1 %||% "(path generation failed)"))
@@ -802,14 +802,14 @@ setMethod(
             stop(sprintf("[as.matrix,H5ClusterRunSummary] Summary dataset not found at path: %s", dset_path))
         }
         ds <- x@obj[[dset_path]]
-        on.exit(if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) try(ds$close(), silent = TRUE), add = TRUE)
+        on.exit(if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) close_h5_safely(ds), add = TRUE)
 
         mat_data <- ds$read() # Use $read() instead of []
 
     }, error = function(e) {
         # Ensure ds handle is closed on error
         if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) {
-            try(ds$close(), silent = TRUE)
+            close_h5_safely(ds)
         }
         stop(sprintf("[as.matrix,H5ClusterRunSummary] Failed to read summary data for scan '%s' from '%s'. Original error: %s",
                      x@scan_name, dset_path, e$message))
@@ -1079,7 +1079,7 @@ make_run_summary <- function(file_source, scan_name,
       stop(sprintf("[make_run_summary] Error accessing or validating summary dataset \'%s\'. Original error: %s", dset_path, e$message))
   }, finally = {
       if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) {
-          try(ds$close(), silent = TRUE)
+          close_h5_safely(ds)
       }
   })
 

--- a/R/cluster_experiment.R
+++ b/R/cluster_experiment.R
@@ -39,8 +39,8 @@ NULL
   
   # Local on.exit for HDF5 handles opened within this helper
   on.exit({
-    if (!is.null(vox_coords_dset) && inherits(vox_coords_dset, "H5D") && vox_coords_dset$is_valid) try(vox_coords_dset$close(), silent = TRUE)
-    if (!is.null(mask_dset_val) && inherits(mask_dset_val, "H5D") && mask_dset_val$is_valid) try(mask_dset_val$close(), silent = TRUE)
+    if (!is.null(vox_coords_dset) && inherits(vox_coords_dset, "H5D") && vox_coords_dset$is_valid) close_h5_safely(vox_coords_dset)
+    if (!is.null(mask_dset_val) && inherits(mask_dset_val, "H5D") && mask_dset_val$is_valid) close_h5_safely(mask_dset_val)
   }, add = TRUE) # Add to existing on.exit handlers if any in calling scope (though this is top-level helper)
 
   tryCatch({
@@ -289,12 +289,12 @@ H5ClusterExperiment <- function(file,
   opened_datasets <- list() 
   on.exit({
     # Close datasets first
-    lapply(opened_datasets, function(ds) if (!is.null(ds) && is(ds, "H5D") && ds$is_valid) try(ds$close(), silent = TRUE))
+    lapply(opened_datasets, function(ds) if (!is.null(ds) && is(ds, "H5D") && ds$is_valid) close_h5_safely(ds))
     # Then close groups
-    lapply(opened_groups, function(grp) if (!is.null(grp) && is(grp, "H5Group") && grp$is_valid) try(grp$close(), silent = TRUE))
+    lapply(opened_groups, function(grp) if (!is.null(grp) && is(grp, "H5Group") && grp$is_valid) close_h5_safely(grp))
     # Finally, close file if opened here and not keeping open
     if (opened_here && !keep_handle_open && !is.null(h5obj) && h5obj$is_valid) {
-         try(h5obj$close(), silent = TRUE)
+         close_h5_safely(h5obj)
     }
     # TODO: Add finalizer registration if keep_handle_open is TRUE
   }, add = TRUE)
@@ -513,7 +513,7 @@ H5ClusterExperiment <- function(file,
          }, finally = {
              # Close the group if we opened it just for the check
              if (!is.null(summary_group) && inherits(summary_group, "H5Group") && summary_group$is_valid) {
-                 try(summary_group$close(), silent = TRUE)
+                 close_h5_safely(summary_group)
              }
          })
     }

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -294,11 +294,11 @@ H5ClusterRunSummary <- function(file, scan_name,
       }
 
   }, error = function(e) {
-      if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) try(ds$close(), silent = TRUE)
+      if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) close_h5_safely(ds)
       if (fh$owns) try(h5obj$close_all(), silent = TRUE)
       stop(sprintf("[H5ClusterRunSummary] Error processing summary dataset '%s': %s", dset_path, e$message))
   }, finally = {
-      if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) try(ds$close(), silent = TRUE)
+      if (!is.null(ds) && inherits(ds, "H5D") && ds$is_valid) close_h5_safely(ds)
   })
 
   # --- 5. Create the object ---

--- a/R/h5_utils.R
+++ b/R/h5_utils.R
@@ -152,7 +152,7 @@ h5_read <- function(h5, path, missing_ok = FALSE, read_args = NULL) {
   }, finally = {
     # Ensure dataset handle is closed
     if (!is.null(dset) && inherits(dset, "H5D") && dset$is_valid) {
-      try(dset$close(), silent = TRUE)
+      close_h5_safely(dset)
     }
   })
 

--- a/R/h5neurovol.R
+++ b/R/h5neurovol.R
@@ -237,7 +237,7 @@ setMethod(
         subvol <- dset[minx:maxx, miny:maxy, minz:maxz, drop=FALSE]
     }, finally = {
         if (!is.null(dset) && inherits(dset, "H5D") && dset$is_valid) {
-            try(dset$close(), silent = TRUE)
+            close_h5_safely(dset)
         }
     })
     if (is.null(subvol)) stop("Failed to read sub-volume data for linear_access.")
@@ -348,7 +348,7 @@ setMethod(
         subvol <- dset[minI:maxI, minJ:maxJ, minK:maxK, drop=FALSE]
     }, finally = {
         if (!is.null(dset) && inherits(dset, "H5D") && dset$is_valid) {
-            try(dset$close(), silent = TRUE)
+            close_h5_safely(dset)
         }
     })
     if (is.null(subvol)) stop("Failed to read sub-volume data.")


### PR DESCRIPTION
## Summary
- use `close_h5_safely()` helper instead of repeated `try(...$close(), silent = TRUE)` calls

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: `bash: R: command not found`)*