### PR TITLE
Update check_same_dims and add tests

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -28,6 +28,14 @@ assert_non_empty_numeric <- function(x, arg, fn) {
 check_same_dims <- function(a, b, dims_to_compare = NULL, msg = NULL) {
   dim_a <- dim(a)
   dim_b <- dim(b)
+
+  # Treat numeric vectors as dimension vectors when dim() is NULL
+  if (is.null(dim_a) && is.numeric(a)) {
+    dim_a <- as.integer(a)
+  }
+  if (is.null(dim_b) && is.numeric(b)) {
+    dim_b <- as.integer(b)
+  }
   
   # Select dimensions to compare
   dims_a_sub <- if (is.null(dims_to_compare)) dim_a else dim_a[dims_to_compare]

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -1,0 +1,14 @@
+library(testthat)
+library(hdf5r)
+library(neuroim2)
+library(fmristore)
+
+# Tests for check_same_dims with dimension vectors
+
+test_that("check_same_dims works with numeric dimension vectors", {
+  expect_silent(fmristore:::check_same_dims(c(10, 5, 2), c(10, 5, 2)))
+})
+
+test_that("check_same_dims fails when numeric dimension vectors differ", {
+  expect_error(fmristore:::check_same_dims(c(2, 3, 4), c(2, 3, 5)), "Dimension mismatch")
+})


### PR DESCRIPTION
## Summary
- enhance `check_same_dims` so numeric vectors are treated as dimension vectors
- cover new behaviour with tests

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*