### PR TITLE
Fix show docs

### DIFF
--- a/R/cluster_array.R
+++ b/R/cluster_array.R
@@ -1095,8 +1095,13 @@ make_run_summary <- function(file_source, scan_name,
   return(run_obj)
 }
 
-#' Show Method for H5ClusterRunSummary
-#' @param object An H5ClusterRunSummary object
+#' Show Methods for H5Cluster Objects
+#'
+#' Display concise summaries for objects in the H5Cluster family,
+#' including \code{H5ClusterRun}, \code{H5ClusterRunSummary},
+#' \code{H5ClusterExperiment}, and \code{LatentNeuroVec}.
+#'
+#' @param object An object from the H5Cluster family
 #' @importFrom cli cli_h1 cli_h2 cli_li col_blue col_green col_yellow col_silver col_red col_magenta symbol cli_text cli_alert_info
 #' @importFrom utils head
 #' @importFrom methods show

--- a/R/cluster_experiment.R
+++ b/R/cluster_experiment.R
@@ -858,4 +858,3 @@ setMethod("show", "H5ClusterExperiment", function(object) {
   }
 })
 
-# TODO: Add show method for H5ClusterExperiment 

--- a/man/show-methods.Rd
+++ b/man/show-methods.Rd
@@ -6,7 +6,7 @@
 \alias{show,H5ClusterRunSummary-method}
 \alias{show,H5ClusterExperiment-method}
 \alias{show,LatentNeuroVec-method}
-\title{Show Method for H5ClusterRunSummary}
+\title{Show Methods for H5Cluster Objects}
 \usage{
 \S4method{show}{H5ClusterRun}(object)
 
@@ -17,10 +17,10 @@
 \S4method{show}{LatentNeuroVec}(object)
 }
 \arguments{
-\item{object}{An H5ClusterRunSummary object}
+\item{object}{An object from the H5Cluster family}
 }
 \description{
-Show Method for H5ClusterRunSummary
+Display a concise summary for H5Cluster objects
 }
 \seealso{
 Other H5Clustered: 


### PR DESCRIPTION
## Summary
- document show methods for H5Cluster objects
- clean up H5ClusterExperiment show method reference

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`