### PR TITLE
Remove unused dataset_attrs variable

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -229,7 +229,6 @@ H5ClusterRunSummary <- function(file, scan_name,
   final_cluster_ids <- cluster_ids
 
   dataset_dims <- NULL
-  dataset_attrs <- NULL
 
   info_res <- tryCatch({
     with_h5_dataset(h5obj, dset_path, function(ds) {


### PR DESCRIPTION
## Summary
- remove `dataset_attrs` initialization from `H5ClusterRunSummary`

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*