### PR TITLE
Validate compress input for H5ClusterRun

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -49,6 +49,10 @@ H5ClusterRun <- function(file, scan_name,
     ))
   }
 
+  if (!is.logical(compress) || length(compress) != 1) {
+    stop("[H5ClusterRun] 'compress' must be a single logical value.")
+  }
+
   # --- 2. Open HDF5 file --- 
   # Use open_h5 with mode 'r' by default. It handles file existence check.
   # Note: open_h5 now returns a list(h5=handle, owns=TRUE/FALSE)

--- a/tests/testthat/test-cluster_run_full.R
+++ b/tests/testthat/test-cluster_run_full.R
@@ -274,6 +274,24 @@ test_that("make_run_full throws errors for invalid inputs", {
   expect_error(H5ClusterRun(file=setup_info$filepath, scan_name=setup_info$scan_name, mask=bad_mask, clusters=setup_info$clusters, n_time=setup_info$n_time), "Dimensions of 'mask' and 'clusters' must match")
   # Test cluster length mismatch
   expect_error(H5ClusterRun(file=setup_info$filepath, scan_name=setup_info$scan_name, mask=setup_info$mask, clusters=bad_clusters, n_time=setup_info$n_time), "Mismatch: clusters@clusters length")
+
+  # Test invalid compress inputs
+  expect_error(
+    H5ClusterRun(file = setup_info$filepath,
+                 scan_name = setup_info$scan_name,
+                 mask = setup_info$mask,
+                 clusters = setup_info$clusters,
+                 n_time = setup_info$n_time,
+                 compress = c(TRUE, FALSE)),
+    "'compress' must be a single logical value")
+  expect_error(
+    H5ClusterRun(file = setup_info$filepath,
+                 scan_name = setup_info$scan_name,
+                 mask = setup_info$mask,
+                 clusters = setup_info$clusters,
+                 n_time = setup_info$n_time,
+                 compress = "yes"),
+    "'compress' must be a single logical value")
   # Test error if n_time cannot be determined
   setup_uninferrable <- setup_test_file_full(clear_cluster_data = TRUE)
   on.exit(cleanup_test_file(setup_uninferrable), add = TRUE)


### PR DESCRIPTION
## Summary
- validate that `compress` is a single logical value when constructing `H5ClusterRun`
- test invalid `compress` arguments

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*