### PR TITLE
Fix verbose option

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -6,6 +6,11 @@
 #' 
 #' This function handles file opening/closing and reads necessary metadata like
 #' \code{n_time} from the HDF5 file if not provided explicitly.
+#'
+#' @details
+#' Diagnostic messages (such as when \code{n_time} is inferred from a dataset)
+#' are printed only when the option \code{fmristore.verbose} is set to
+#' \code{TRUE} via \code{options(fmristore.verbose = TRUE)}.
 #' 
 #' @param file Character string path to the HDF5 file.
 #' @param scan_name The character string name of the scan (e.g., "run1").
@@ -93,7 +98,9 @@ H5ClusterRun <- function(file, scan_name,
                     dims <- dset_cid1$dims
                     if (length(dims) == 2) {
                         determined_n_time <- dims[2]
-                        message(sprintf("[H5ClusterRun] Inferred n_time = %d from dataset '%s'.", determined_n_time, dset_path_cid1))
+                        if (isTRUE(getOption("fmristore.verbose"))) {
+                          message(sprintf("[H5ClusterRun] Inferred n_time = %d from dataset '%s'.", determined_n_time, dset_path_cid1))
+                        }
                     }
                }, finally = {
                     if(!is.null(dset_cid1) && dset_cid1$is_valid) try(dset_cid1$close())

--- a/man/H5ClusteredRunFull.Rd
+++ b/man/H5ClusteredRunFull.Rd
@@ -37,3 +37,8 @@ voxel-level clustered data from an HDF5 file.
 This function handles file opening/closing and reads necessary metadata like
 \code{n_time} from the HDF5 file if not provided explicitly.
 }
+\details{
+Diagnostic messages (such as when \code{n_time} is inferred from a dataset) are
+printed only when the option \code{fmristore.verbose} is set to \code{TRUE} via
+\code{options(fmristore.verbose = TRUE)}.
+}

--- a/tests/testthat/test-cluster_run_full.R
+++ b/tests/testthat/test-cluster_run_full.R
@@ -237,21 +237,36 @@ test_that("make_run_full reads n_time from HDF5 metadata dataset if NULL", {
   expect_silent(h5file(run_meta)$close_all())
 })
 
-test_that("make_run_full infers n_time from first cluster dataset if NULL and other sources missing", {
+test_that("inference message depends on fmristore.verbose option", {
   setup_none <- setup_test_file_full(write_n_time_attr = FALSE, write_n_time_meta = FALSE)
   on.exit(cleanup_test_file(setup_none))
 
-  # Use new constructor
-  expect_message( # Expect message about inference
-      run_infer <- H5ClusterRun(file = setup_none$filepath,
-                                    scan_name = setup_none$scan_name,
-                                    mask = setup_none$mask,
-                                    clusters = setup_none$clusters,
-                                    n_time = NULL),
-      "Inferred n_time"
+  expect_message(
+    run_infer_verbose <- withr::with_options(
+      list(fmristore.verbose = TRUE),
+      H5ClusterRun(file = setup_none$filepath,
+                   scan_name = setup_none$scan_name,
+                   mask = setup_none$mask,
+                   clusters = setup_none$clusters,
+                   n_time = NULL)
+    ),
+    "Inferred n_time"
   )
-  expect_equal(run_infer@n_time, setup_none$n_time)
-  expect_silent(h5file(run_infer)$close_all())
+  expect_equal(run_infer_verbose@n_time, setup_none$n_time)
+  expect_silent(h5file(run_infer_verbose)$close_all())
+
+  expect_no_message(
+    run_infer_silent <- withr::with_options(
+      list(fmristore.verbose = FALSE),
+      H5ClusterRun(file = setup_none$filepath,
+                   scan_name = setup_none$scan_name,
+                   mask = setup_none$mask,
+                   clusters = setup_none$clusters,
+                   n_time = NULL)
+    )
+  )
+  expect_equal(run_infer_silent@n_time, setup_none$n_time)
+  expect_silent(h5file(run_infer_silent)$close_all())
 })
 
 


### PR DESCRIPTION
## Summary
- respect `fmristore.verbose` option in `H5ClusterRun`
- document the verbose option
- test message emission with the option toggled

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`