### PR TITLE
Ensure H5NeuroVol closes handle on failed validation

### DIFF
--- a/R/h5neurovol.R
+++ b/R/h5neurovol.R
@@ -46,7 +46,11 @@ H5NeuroVol <- function(file_name) {
   assert_that(is.character(file_name))
   assert_that(file.exists(file_name))
 
-  h5obj <- hdf5r::H5File$new(file_name)
+  # open file read-only
+  h5obj <- hdf5r::H5File$new(file_name, mode = "r")
+
+  # make sure handle is closed on failure
+  on.exit(safe_h5_close(h5obj))
 
   # Check the "rtype" attribute
   rtype <- try(hdf5r::h5attr(h5obj, which="rtype"), silent=TRUE)
@@ -69,6 +73,7 @@ H5NeuroVol <- function(file_name) {
     trans  = h5obj[["space/trans"]][,]
   )
 
+  on.exit(NULL)
   new("H5NeuroVol", space=sp, h5obj=h5obj)
 }
 

--- a/tests/testthat/test-h5neurovol-invalid.R
+++ b/tests/testthat/test-h5neurovol-invalid.R
@@ -1,0 +1,23 @@
+library(testthat)
+library(hdf5r)
+library(neuroim2)
+
+# Ensure invalid H5NeuroVol closes handle on error
+
+test_that("invalid H5NeuroVol file closes handle", {
+  skip_if_not_installed("hdf5r")
+  tmp <- tempfile(fileext = ".h5")
+  on.exit(unlink(tmp), add = TRUE)
+
+  # create a malformed file
+  h5 <- H5File$new(tmp, mode = "w")
+  h5attr(h5, "rtype") <- "WrongType"
+  h5$create_group("space")
+  h5$create_dataset("space/dim", robj = c(2L,2L,2L))
+  h5$close_all()
+
+  before <- length(h5validObjects())
+  expect_error(H5NeuroVol(tmp))
+  after <- length(h5validObjects())
+  expect_equal(after, before)
+})


### PR DESCRIPTION
## Summary
- open H5NeuroVol files explicitly read-only
- close the handle if validation fails
- add regression test checking that invalid files do not leave open handles

## Testing
- `R -q -e "cat('R available')"` *(fails: command not found)*