### PR TITLE
Fix DenseNeuroVol -> H5NeuroVol coercion

### DIFF
--- a/R/h5neurovol.R
+++ b/R/h5neurovol.R
@@ -408,9 +408,7 @@ setMethod(
 setAs(
   from = "DenseNeuroVol",
   to   = "H5NeuroVol",
-  def  = function(from) {
-    to_nih5_vol(from, file_name=NULL, data_type="FLOAT")
-  }
+  def  = function(from) as_h5(from, file = NULL, data_type = "FLOAT")
 )
 
 #' Show Method for H5NeuroVol

--- a/tests/testthat/test-h5classes.R
+++ b/tests/testthat/test-h5classes.R
@@ -27,6 +27,23 @@ test_that("H5NeuroVol construction and subsetting works", {
   expect_equal(as.array(subset), data[1:5, 1:5, 1:5], tolerance=1e-6)
 })
 
+test_that("coercion via as() uses as_h5 for DenseNeuroVol", {
+  dims <- c(4, 4, 4)
+  sp   <- NeuroSpace(dims)
+  arr  <- array(rnorm(prod(dims)), dim = dims)
+  dvol <- DenseNeuroVol(arr, sp)
+
+  h5vol <- as(dvol, "H5NeuroVol")
+
+  expect_true(inherits(h5vol, "H5NeuroVol"))
+  expect_equal(dim(h5vol), dims)
+  expect_equal(h5vol[2,2,2], arr[2,2,2], tolerance = 1e-6)
+
+  filepath <- h5vol@h5obj$get_filename()
+  close(h5vol)
+  unlink(filepath)
+})
+
 test_that("H5NeuroVec construction and series extraction works", {
   # Create test data
   dims <- c(10, 10, 10)


### PR DESCRIPTION
## Summary
- dispatch DenseNeuroVol->H5NeuroVol coercion via `as_h5`
- test coercion with `as()`

## Testing
- `R -q -e "quit()"` *(fails: command not found)*