### PR TITLE
Remove unused variables from read_labeled_vec

### DIFF
--- a/R/labeled_vec.R
+++ b/R/labeled_vec.R
@@ -323,11 +323,8 @@ read_labeled_vec <- function(file_path) {
   # CRITICAL: Remove on.exit/defer call for h5obj. 
   # Closing is now the responsibility of the user via the close() method 
   # if fh$owns is TRUE.
-  # Example removed call: 
+  # Example removed call:
   # if (fh$owns) on.exit(safe_h5_close(h5obj), add = TRUE)
-
-  hdr_grp <- NULL # Initialize for finally block
-  hdr_values <- list()
 
   # Helper to read dataset from header group if present
   .rd_hdr <- function(nm) {


### PR DESCRIPTION
## Summary
- remove unused `hdr_grp` and `hdr_values` variables in `read_labeled_vec`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*
