### PR TITLE
Fix Rd line width notes

### DIFF
--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -707,7 +707,8 @@ setGeneric(".dataset_path",
 #'   message("  #                       scan_metadata = scan_meta)")
 #'   message("  # print(h5_clust_obj)")
 #'   message("  # if (!is.null(h5_clust_obj)) try(close(h5_clust_obj), silent=TRUE)")
-#'   message("  # if (file.exists(attr(h5_clust_obj, \"filepath\"))) unlink(attr(h5_clust_obj, \"filepath\"))")
+#'   message("  # if (file.exists(attr(h5_clust_obj, \"filepath\")))")
+#'   message("  #   unlink(attr(h5_clust_obj, \"filepath\"))")
 #' 
 #' }
 #'

--- a/R/cluster_array.R
+++ b/R/cluster_array.R
@@ -474,7 +474,9 @@ setMethod(
 #'       # Example: Access first 5 linear indices and last 5
 #'       indices_to_access <- c(1:5, (total_elements-4):total_elements)
 #'       # Ensure indices are within bounds if total_elements is small
-#'       indices_to_access <- indices_to_access[indices_to_access <= total_elements & indices_to_access > 0]
+#'       indices_to_access <- indices_to_access[
+#'         indices_to_access <= total_elements & indices_to_access > 0
+#'       ]
 #'       indices_to_access <- unique(indices_to_access)
 #'       
 #'       if (length(indices_to_access) > 0) {

--- a/man/as_h5-methods.Rd
+++ b/man/as_h5-methods.Rd
@@ -201,7 +201,8 @@ tryCatch({
   message("  #                       scan_metadata = scan_meta)")
   message("  # print(h5_clust_obj)")
   message("  # if (!is.null(h5_clust_obj)) try(close(h5_clust_obj), silent=TRUE)")
-  message("  # if (file.exists(attr(h5_clust_obj, \"filepath\"))) unlink(attr(h5_clust_obj, \"filepath\"))")
+  message("  # if (file.exists(attr(h5_clust_obj, \"filepath\")))")
+  message("  #   unlink(attr(h5_clust_obj, \"filepath\"))")
 
 }
 

--- a/man/linear_access-methods.Rd
+++ b/man/linear_access-methods.Rd
@@ -90,7 +90,9 @@ if (requireNamespace("neuroim2", quietly = TRUE) &&
       # Example: Access first 5 linear indices and last 5
       indices_to_access <- c(1:5, (total_elements-4):total_elements)
       # Ensure indices are within bounds if total_elements is small
-      indices_to_access <- indices_to_access[indices_to_access <= total_elements & indices_to_access > 0]
+      indices_to_access <- indices_to_access[
+        indices_to_access <= total_elements & indices_to_access > 0
+      ]
       indices_to_access <- unique(indices_to_access)
       
       if (length(indices_to_access) > 0) {


### PR DESCRIPTION
## Summary
- avoid overly long example lines in `as_h5` documentation
- break lines in linear_access documentation

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4d5cb6a4832db618aa6c7e4533ae